### PR TITLE
common:socket: add retry count to socket connect

### DIFF
--- a/common/include/mapf/common/socket.h
+++ b/common/include/mapf/common/socket.h
@@ -27,7 +27,8 @@ public:
     Socket();
     virtual ~Socket();
 
-    int Connect(const std::string &addr, bool retry = true);
+    // -1 - endless, 0 - one shot, >0 - num of retries
+    int Connect(const std::string &addr, int max_retries = -1);
 
     void Close();
 


### PR DESCRIPTION
Elaborate:
Socket::connect can fail if no one is listening on the receiving end, so we
originally added retry mechanism without retry limit (which means
connect will always block if it can't connect).
This change adds retry count that allows retrying only a defined amount
of times, or -1 for infinite retries (which is the default).

Tests:
build & unitests (both on nng and zmq)

Signed-off-by: Lior Amram <lior.amram@intel.com>